### PR TITLE
Integrate Tailwind CSS and Google Fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Team Health</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 </head>
-<body>
+<body class="bg-gray-100 text-gray-900">
     <header>
         <nav>
             <ul>

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -12,6 +12,13 @@ const theme = createTheme({
   typography: {
     fontFamily: 'Roboto, Arial, sans-serif',
   },
+  overrides: {
+    MuiButton: {
+      root: {
+        '@apply bg-primary text-white': {},
+      },
+    },
+  },
 });
 
 export default theme;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  purge: [],
+  darkMode: false, // or 'media' or 'class'
+  theme: {
+    extend: {
+      colors: {
+        primary: '#1976d2',
+        secondary: '#dc004e',
+      },
+      fontFamily: {
+        sans: ['Roboto', 'Arial', 'sans-serif'],
+      },
+    },
+  },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
Fixes #5

Integrate Tailwind CSS and Google Fonts to match Material UI design specifications.

* **index.html**
  - Add Tailwind CSS CDN link in the `<head>` section.
  - Add Google Fonts link for Roboto in the `<head>` section.
  - Add `class` attribute to `<body>` with Tailwind CSS classes.

* **tailwind.config.js**
  - Configure Tailwind CSS to match Material UI themes.

* **src/styles/theme.js**
  - Ensure Tailwind CSS classes are compatible with Material UI themes.
  - Add Tailwind CSS classes to Material UI Button component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/paialex/team-health/issues/5?shareId=9ce864b5-5f8e-4ec8-8dc7-2cfc0e108b60).